### PR TITLE
Gpgme: Timestamps are CLong

### DIFF
--- a/bindings-gpgme/src/Bindings/Gpgme.hsc
+++ b/bindings-gpgme/src/Bindings/Gpgme.hsc
@@ -213,8 +213,8 @@ module Bindings.Gpgme where
 #field next , Ptr <_gpgme_key_sig>
 #field pubkey_algo , <gpgme_pubkey_algo_t>
 #field keyid , CString
-#field timestamp , CInt
-#field expires , CInt
+#field timestamp , CLong
+#field expires , CLong
 #field status , <gpgme_error_t>
 #field uid , CString
 #field name , CString


### PR DESCRIPTION
This seems to be a bug.