### PR TITLE
Fix printf formatting warnings

### DIFF
--- a/bindings.dsl.h
+++ b/bindings.dsl.h
@@ -185,8 +185,8 @@
     printf(" -> (");bc_typemarkup(# type);printf(")\n"); \
 
 static struct {
-	int n, array_size[500], is_union[500], is_fam[500];
-	uintmax_t offset[500];
+	int n, is_union[500], is_fam[500];
+	uintmax_t array_size[500], offset[500];
 	char fname[500][1000], ftype[500][1000];
 } bc_fielddata;
 


### PR DESCRIPTION
Lines like this:

```c
printf("  let s = div %" PRIuMAX " $ sizeOf $ (undefined :: ",
  bc_fielddata.array_size[i]);
```

cause GHC to emit warnings when `-Wall` is on since `array_size` is an `int` array. To suppress this warning, I changed `array_size` to be a `uintmax_t` array.