### PR TITLE
Split #pattern into #num_pattern and #fractional_pattern

### DIFF
--- a/bindings.dsl.h
+++ b/bindings.dsl.h
@@ -86,11 +86,11 @@
 #define bc_float(name) printf("%Le",(long double)(name)) \
 
 #if __GLASGOW_HASKELL__ >= 710
-# define bc_patsig(name) \
+# define bc_patsig(name,constr) \
     printf("pattern ");bc_conid(name); \
-    printf(" :: () => (Eq a, Num a) => a");
+    printf(" :: () => (Eq a, %s a) => a",constr);
 #else
-# define bc_patsig(name)
+# define bc_patsig(name,constr)
 #endif
 
 #define hsc_num(name) \
@@ -102,9 +102,13 @@
     bc_varid(# name);printf(" :: (Fractional a) => a\n"); \
 
 #if __GLASGOW_HASKELL__ >= 708
-# define hsc_pattern(name) \
+# define hsc_num_pattern(name) \
      printf("pattern ");bc_conid(# name);printf(" = "); \
-     bc_decimal(name);printf("\n");bc_patsig(# name)
+     bc_decimal(name);printf("\n");bc_patsig(# name,"Num");
+
+# define hsc_fractional_pattern(name) \
+     printf("pattern ");bc_conid(# name);printf(" = "); \
+     bc_float(name);printf("\n");bc_patsig(# name,"Fractional");
 #endif
 
 #define hsc_pointer(name) \


### PR DESCRIPTION
It occurred to me that `#pattern` only works on non-fractional numbers. To avoid this discrepancy, I decided to rename `#pattern` to `#num_pattern` and add `#fractional_pattern` for symmetry.

Follow-up to #22.