### PR TITLE
add linkage with hdf5 and hdf5_hl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,14 @@ language: nix
 sudo: true
 
 git:
-  depth: 1
-
-install:
-  - git clone --depth=1 https://github.com/$TRAVIS_REPO_SLUG.git bindings-DSL
-  - cd bindings-DSL
-  - git checkout -qf $TRAVIS_COMMIT
+  depth: 5
 
 env:
   global:
   matrix:
-    - GHCVERSION=ghc802
-    - GHCVERSION=ghc822
-    - GHCVERSION=ghc843
+    - GHCVERSION=ghc822Binary
+    - GHCVERSION=ghc844
+    - GHCVERSION=ghc863Binary
 
 matrix:
   allow_failures:
@@ -29,3 +24,4 @@ script:
 branches:
   only:
     - master
+    - link-with-hdf5

--- a/bindings-gpgme/default.nix
+++ b/bindings-gpgme/default.nix
@@ -1,30 +1,29 @@
-{ compiler    ? "ghc822"
-, doBenchmark ? false
-, doTracing   ? false
-, doStrict    ? false
-, rev         ? "d1ae60cbad7a49874310de91cd17708b042400c8"
-, sha256      ? "0a1w4702jlycg2ab87m7n8frjjngf0cis40lyxm3vdwn7p4fxikz"
-, pkgs        ? import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-    inherit sha256; }) {
-    config.allowUnfree = true;
-    config.allowBroken = false;
-  }
-, returnShellEnv ? pkgs.lib.inNixShell
-, mkDerivation ? null
-}:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
 
-let haskellPackages = pkgs.haskell.packages.${compiler};
+let
 
-in haskellPackages.developPackage {
-  root = ./.;
+  inherit (nixpkgs) pkgs;
 
-  source-overrides = {
-  };
+  f = { mkDerivation, base, bindings-DSL, gpgme, stdenv }:
+      mkDerivation {
+        pname = "bindings-gpgme";
+        version = "0.1.7";
+        src = ./.;
+        libraryHaskellDepends = [ base bindings-DSL ];
+        librarySystemDepends = [ gpgme ];
+        homepage = "https://github.com/jwiegley/bindings-dsl";
+        description = "Project bindings-* raw interface to gpgme";
+        license = stdenv.lib.licenses.bsd3;
+      };
 
-  modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {
-    inherit doBenchmark;
-  });
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
 
-  inherit returnShellEnv;
-}
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv

--- a/bindings-hdf5/bindings-hdf5.cabal
+++ b/bindings-hdf5/bindings-hdf5.cabal
@@ -38,6 +38,7 @@ library
     Bindings.HDF5.Types
     Bindings.HDF5.HighLevelAPI
     Bindings.HDF5.LowLevelAPI
+  extra-libraries: hdf5, hdf5_hl
 source-repository head
   type: git
   location: git://github.com/jwiegley/bindings-dsl

--- a/bindings-posix/default.nix
+++ b/bindings-posix/default.nix
@@ -1,30 +1,27 @@
-{ compiler    ? "ghc822"
-, doBenchmark ? false
-, doTracing   ? false
-, doStrict    ? false
-, rev         ? "d1ae60cbad7a49874310de91cd17708b042400c8"
-, sha256      ? "0a1w4702jlycg2ab87m7n8frjjngf0cis40lyxm3vdwn7p4fxikz"
-, pkgs        ? import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-    inherit sha256; }) {
-    config.allowUnfree = true;
-    config.allowBroken = false;
-  }
-, returnShellEnv ? pkgs.lib.inNixShell
-, mkDerivation ? null
-}:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
 
-let haskellPackages = pkgs.haskell.packages.${compiler};
+let
 
-in haskellPackages.developPackage {
-  root = ./.;
+  inherit (nixpkgs) pkgs;
 
-  source-overrides = {
-  };
+  f = { mkDerivation, base, bindings-DSL, stdenv }:
+      mkDerivation {
+        pname = "bindings-posix";
+        version = "1.2.7";
+        src = ./.;
+        libraryHaskellDepends = [ base bindings-DSL ];
+        description = "Project bindings-* raw interface to Posix";
+        license = stdenv.lib.licenses.bsd3;
+      };
 
-  modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {
-    inherit doBenchmark;
-  });
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
 
-  inherit returnShellEnv;
-}
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv


### PR DESCRIPTION
I found that the shared object for `bindings-hdf5` is not linked with `libhdf5.so` and `libhdf5_hl.so`. This can cause problems in GHCi, like so:

```
$ stack repl
*Bindings.HDF5.Types Bindings.HDF5 Bindings.HDF5.HighLevelAPI Bindings.HDF5.LowLevelAPI Bindings.HDF5.Types> Bindings.HDF5.c'H5open 
ghc: ^^ Could not load 'H5check_version', dependency unresolved. See top entry above.


ByteCodeLink: can't find label
During interactive linking, GHCi couldn't find the following symbol:
  H5check_version
This may be due to you not asking GHCi to load extra object files,
archives or DLLs needed by your current session.  Restart GHCi, specifying
the missing library using the -L/path/to/object/dir and -lmissinglibname
flags, or simply by naming the relevant files on the GHCi command line.
Alternatively, this link failure might indicate a bug in GHCi.
If you suspect the latter, please send a bug report to:
  glasgow-haskell-bugs@haskell.org

*Bindings.HDF5.Types Bindings.HDF5 Bindings.HDF5.HighLevelAPI Bindings.HDF5.LowLevelAPI Bindings.HDF5.Types> 
```

This seems due to the fact that the shared object which is built by `stack build` is not linked with `libhdf5.so` and `libhdf5_hl.so`:

```
$ ldd libHSbindings-hdf5-0.1.2-KfKwXj5IPLyKhFzrLF6QxQ-ghc8.6.5.so 
	linux-vdso.so.1 =>  (0x00007ffe5a936000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f19260ae000)
	libHSbindings-DSL-1.0.25-2kwolusgL8L5V1adlcppFi-ghc8.6.5.so => /redacted/.stack/snapshots/x86_64-linux/af106f1d68e31ad0380a86551f69303929efb450012401048941c855503533ad/8.6.5/lib/x86_64-linux-ghc-8.6.5/libHSbindings-DSL-1.0.25-2kwolusgL8L5V1adlcppFi-ghc8.6.5.so (0x00007f1926406000)
	libHSbase-4.12.0.0-ghc8.6.5.so => /redacted/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/base-4.12.0.0/libHSbase-4.12.0.0-ghc8.6.5.so (0x00007f1925720000)
	libHSinteger-gmp-1.0.2.0-ghc8.6.5.so => /redacted/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/integer-gmp-1.0.2.0/libHSinteger-gmp-1.0.2.0-ghc8.6.5.so (0x00007f19256e1000)
	libHSghc-prim-0.5.3-ghc8.6.5.so => /redacted/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/ghc-prim-0.5.3/libHSghc-prim-0.5.3-ghc8.6.5.so (0x00007f1925252000)
	libgmp.so.10 => /usr/lib/x86_64-linux-gnu/libgmp.so.10 (0x00007f1924fd2000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1924c08000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f19263b7000)
```

I propose to add `extra-libraries` in the cabal file to make the shared object linked with the HDF5 libraries. With this change I get

```
$ ldd libHSbindings-hdf5-0.1.2-At2Qy1W89KKGUfq74sZoZl-ghc8.6.5.so 
	linux-vdso.so.1 =>  (0x00007ffcb93e1000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f10d7601000)
	libhdf5.so.10 => /opt/hdf5-1.8/lib/libhdf5.so.10 (0x00007f10d710b000)
	libhdf5_hl.so.10 => /opt/hdf5-1.8/lib/libhdf5_hl.so.10 (0x00007f10d6ee8000)
	libHSbindings-DSL-1.0.25-2kwolusgL8L5V1adlcppFi-ghc8.6.5.so => /redacted/.stack/snapshots/x86_64-linux/af106f1d68e31ad0380a86551f69303929efb450012401048941c855503533ad/8.6.5/lib/x86_64-linux-ghc-8.6.5/libHSbindings-DSL-1.0.25-2kwolusgL8L5V1adlcppFi-ghc8.6.5.so (0x00007f10d7957000)
	libHSbase-4.12.0.0-ghc8.6.5.so => /redacted/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/base-4.12.0.0/libHSbase-4.12.0.0-ghc8.6.5.so (0x00007f10d655a000)
	libHSinteger-gmp-1.0.2.0-ghc8.6.5.so => /redacted/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/integer-gmp-1.0.2.0/libHSinteger-gmp-1.0.2.0-ghc8.6.5.so (0x00007f10d651b000)
	libHSghc-prim-0.5.3-ghc8.6.5.so => /redacted/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/ghc-prim-0.5.3/libHSghc-prim-0.5.3-ghc8.6.5.so (0x00007f10d608c000)
	libgmp.so.10 => /usr/lib/x86_64-linux-gnu/libgmp.so.10 (0x00007f10d5e0c000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f10d5a42000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f10d790a000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f10d5828000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f10d5624000)
```

which works fine in `stack repl`.