### PR TITLE
Update Utilities.hs

### DIFF
--- a/Bindings/Utilities.hs
+++ b/Bindings/Utilities.hs
@@ -1,6 +1,6 @@
-module Bindings.Utilities (
-	storableCast,
-	storableCastArray,
+module Bindings.Utilities
+  ( storableCast
+  , storableCastArray
   ) where
 
 import Foreign.C


### PR DESCRIPTION
fixes the following compile warning:

```
bindings-DSL> Bindings\Utilities.hs:2:1: warning: [-Wtabs]
bindings-DSL>     Tab character found here, and in 11 further locations.
bindings-DSL>     Please use spaces instead.
bindings-DSL>   |
bindings-DSL> 2 |         storableCast,
bindings-DSL>   | ^^^^^^^^
```