### PR TITLE
add gpgme_op_delete_ext & gpgme_op_delete_ext_start

### DIFF
--- a/bindings-gpgme/src/Bindings/Gpgme.hsc
+++ b/bindings-gpgme/src/Bindings/Gpgme.hsc
@@ -532,6 +532,8 @@ module Bindings.Gpgme where
 #ccall gpgme_op_genkey_result , <gpgme_ctx_t> -> IO <gpgme_genkey_result_t>
 #ccall gpgme_op_delete_start , <gpgme_ctx_t> -> <gpgme_key_t> -> CInt -> IO <gpgme_error_t>
 #ccall gpgme_op_delete , <gpgme_ctx_t> -> <gpgme_key_t> -> CInt -> IO <gpgme_error_t>
+#ccall gpgme_op_delete_ext , <gpgme_ctx_t> -> <gpgme_key_t> -> CUInt -> IO <gpgme_error_t>
+#ccall gpgme_op_delete_ext_start , <gpgme_ctx_t> -> <gpgme_key_t> -> CUInt -> IO <gpgme_error_t>
 #ccall gpgme_op_edit_start , <gpgme_ctx_t> -> <gpgme_key_t> -> <gpgme_edit_cb_t> -> Ptr () -> <gpgme_data_t> -> IO <gpgme_error_t>
 #ccall gpgme_op_edit , <gpgme_ctx_t> -> <gpgme_key_t> -> <gpgme_edit_cb_t> -> Ptr () -> <gpgme_data_t> -> IO <gpgme_error_t>
 #ccall gpgme_op_card_edit_start , <gpgme_ctx_t> -> <gpgme_key_t> -> <gpgme_edit_cb_t> -> Ptr () -> <gpgme_data_t> -> IO <gpgme_error_t>


### PR DESCRIPTION
hi, 

Frankly, I am very unsure if this is all that's needed to add bindings for the two "new" functions (added with 1.9.1): https://www.gnupg.org/documentation/manuals/gpgme/Deleting-Keys.html

I'd like to use these in h-gpgme so would be cool if you could cut a release. I know it's been long since this project was updated, so if you need any help, please let me know :)