### PR TITLE
Add the constants for ECC, ECDSA, ECDH and EDDSA

### DIFF
--- a/bindings-gpgme/src/Bindings/Gpgme.hsc
+++ b/bindings-gpgme/src/Bindings/Gpgme.hsc
@@ -50,6 +50,10 @@ module Bindings.Gpgme where
 #num GPGME_PK_ELG_E
 #num GPGME_PK_DSA
 #num GPGME_PK_ELG
+#num GPGME_PK_ECC
+#num GPGME_PK_ECDSA
+#num GPGME_PK_ECDH
+#num GPGME_PK_EDDSA
 
 -- ** Hash algorithms
 #integral_t gpgme_hash_algo_t


### PR DESCRIPTION
These should be there since 1.5.0, 1.3.0, 1.3.0 and 1.7.0 respectively according to https://www.gnupg.org/documentation/manuals/gpgme/Public-Key-Algorithms.html
