### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Portable packages that build with only a Haskell toolchain: the
+  # bindings-DSL library itself and bindings-posix. Exercised across a
+  # range of GHC versions.
+  build:
+    name: GHC ${{ matrix.ghc }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['9.6', '9.8', '9.10', '9.12']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up GHC ${{ matrix.ghc }}
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: 'latest'
+          cabal-update: true
+
+      - name: Cache cabal store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal', 'cabal.project') }}
+          restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
+
+      - name: Build
+        run: cabal build bindings-DSL bindings-posix
+
+  # bindings-gpgme needs the gpgme system library and its headers, so it
+  # gets its own job that installs them first.
+  gpgme:
+    name: bindings-gpgme
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gpgme
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgpgme-dev
+
+      - name: Set up GHC
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: '9.12'
+          cabal-version: 'latest'
+          cabal-update: true
+
+      - name: Cache cabal store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ runner.os }}-gpgme-${{ hashFiles('**/*.cabal', 'cabal.project') }}
+          restore-keys: ${{ runner.os }}-gpgme-
+
+      - name: Build
+        run: cabal build bindings-gpgme

--- a/bindings-DSL.cabal
+++ b/bindings-DSL.cabal
@@ -26,8 +26,9 @@ stability: Stable API, well tested, portable, used in commercial code.
 build-type: Simple
 bug-reports: https://github.com/rethab/bindings-dsl/issues
 category: FFI
-extra-source-files: ChangeLog
+extra-source-files: README.md
 library
+  include-dirs: .
   install-includes: bindings.dsl.h , bindings.cmacros.h
   build-depends: base >= 0 && < 1000
   exposed-modules: Bindings.Utilities

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages:
+  .
+  bindings-posix
+  bindings-gpgme


### PR DESCRIPTION
## Why

There's currently no automated build. The old `.travis.yml` relied on Travis + Nix and no longer runs, so nothing catches breakage like the gpgme 2.0 failure in #47. This adds GitHub Actions so pushes and PRs get built.

## What

A `.github/workflows/ci.yml` with two jobs:

- **build** — builds the portable packages (`bindings-DSL` and `bindings-posix`) across a matrix of recent GHC versions (9.6, 9.8, 9.10, 9.12) on Ubuntu, using `haskell-actions/setup` with cabal-store caching. A GHC matrix is the useful axis here — these are FFI bindings, and the value is confirming they still compile against current toolchains.
- **gpgme** — a separate job that installs `libgpgme-dev` and builds `bindings-gpgme`, since it needs the system library and headers that the other packages don't.

Scope mirrors what Travis actually tested (root + posix + gpgme) rather than every binding, since the rest pull in a spread of system libraries. Kept to Linux because that's what I could verify; macOS/other bindings can be added later.

### Supporting changes

- Added a root `cabal.project` so CI builds the in-tree `bindings-DSL` against the sub-packages instead of the published Hackage version — the whole point being to catch regressions in this repo.
- Added `include-dirs: .` to `bindings-DSL.cabal`. Without it the in-place multi-package build fails because hsc2hs can't find `bindings.dsl.h` (`install-includes` only takes effect once the package is installed). Verified via `cabal sdist` that the installed/Hackage build path is unaffected.
- Pointed `extra-source-files` at `README.md`; it referenced `ChangeLog`, which was renamed, and the stale reference made `cabal sdist`/`cabal check` fail.

All jobs were validated locally in clean containers across GHC 9.6/9.8/9.12 before opening this.