### PR TITLE
Document the macOS/Homebrew build for bindings-gpgme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,36 @@
 # bindings-dsl
 
+## Building bindings-gpgme on macOS with Homebrew
+
+`gpgme.h` includes `<gpg-error.h>`, and Homebrew ships `libgpg-error` as a keg of
+its own, so both prefixes have to be on the include and library paths. Passing
+only gpgme's prefix leaves the nested include unresolved and the build fails with
+a misleading complaint about a missing `gpgme.h`.
+
+```sh
+brew install gpgme libgpg-error
+
+cabal build bindings-gpgme \
+  --extra-include-dirs="$(brew --prefix gpgme)/include" \
+  --extra-include-dirs="$(brew --prefix libgpg-error)/include" \
+  --extra-lib-dirs="$(brew --prefix gpgme)/lib" \
+  --extra-lib-dirs="$(brew --prefix libgpg-error)/lib"
+```
+
+With stack, list both prefixes in `stack.yaml` (`brew --prefix` is
+`/opt/homebrew` on Apple silicon and `/usr/local` on Intel):
+
+```yaml
+extra-include-dirs:
+  - /opt/homebrew/opt/gpgme/include
+  - /opt/homebrew/opt/libgpg-error/include
+extra-lib-dirs:
+  - /opt/homebrew/opt/gpgme/lib
+  - /opt/homebrew/opt/libgpg-error/lib
+```
+
+## Changelog
+
 Unreleased
 
 * bindings-gpgme: hide the trust item API when building against gpgme 2.0,


### PR DESCRIPTION
Building `bindings-gpgme` on macOS with Homebrew fails in a way that points at the wrong culprit: `gpgme.h` does `#include <gpg-error.h>`, and Homebrew ships `libgpg-error` as a keg separate from `gpgme`. Pointing `--extra-include-dirs` at gpgme's prefix alone therefore still fails, and cabal reports it as a missing `gpgme.h` — so people go hunting for a header that is in fact right where they put it. The issue reporter lost a good while to this.

This adds a short build section to the README covering the cabal flags and the `stack.yaml` equivalent, naming both prefixes and saying why both are needed.

Adding `pkgconfig-depends: gpgme >= 1.13` to the cabal file would fix this at the root, but it is deliberately left out here: it makes pkg-config a hard build requirement for every downstream consumer (h-gpgme included) and is a known source of breakage on Windows/msys.

Fixes #43