### PR TITLE
bindings-libcddb: fix const qualifier on CDDB_CATEGORY global array

### DIFF
--- a/bindings-libcddb/src/inlines.c
+++ b/bindings-libcddb/src/inlines.c
@@ -2,4 +2,4 @@
 #include <cddb/cddb.h>
 
 BC_INLINE1(SEARCHCAT,cddb_cat_t,cddb_cat_t)
-BC_GLOBALARRAY(CDDB_CATEGORY,char*)
+BC_GLOBALARRAY(CDDB_CATEGORY,const char*)


### PR DESCRIPTION
libcddb declares the category table as `extern const char *CDDB_CATEGORY[]`, but `inlines.c` instantiated `BC_GLOBALARRAY` with `char*`. The macro builds the accessor as `type const *`, so with `char*` it returned `char *const *` while the array itself decays to `const char **` — the `const` on the pointed-to `char` was silently discarded.

GCC has always considered this ill-formed, but only warned about it (`-Wdiscarded-array-qualifiers`) up to GCC 13. GCC 14 promotes the nested-qualifier mismatch to an error by default, so the package stopped compiling.

Instantiating the macro with `const char*` gives `const char *const *`, which matches the declaration. This is contained to the C side: `BC_GLOBALARRAY` in `bindings.cmacros.h` is deliberately left alone so out-of-tree users are unaffected, and `hsc_globalarray` derives the Haskell type purely from its own argument, so `#globalarray CDDB_CATEGORY , CString` still generates `Ptr CString`. No API change.

Fixes #46