### PR TITLE
Emit type signatures before value bindings so Haddock picks up comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,49 @@
 # bindings-dsl
 
+Full documentation is on the [wiki](https://github.com/rethab/bindings-dsl/wiki).
+
+## Haddock
+
+A `-- |` comment placed above a macro invocation is picked up by Haddock and
+documents the declarations the macro generates:
+
+```haskell
+-- | The maximum length of a name.
+#num NAME_MAX
+
+-- | Opens a file.
+#ccall open , CString -> CInt -> IO CInt
+```
+
+This works for `#num`, `#fractional`, `#pointer`, `#function_pointer`,
+`#num_pattern`, `#fractional_pattern`, `#ccall`, `#cinline`, `#globalvar`,
+`#opaque_t`, `#integral_t`, `#synonym_t`, `#callback_t` and `#starttype`.
+
+Two things cannot be documented this way:
+
+* the record fields of a `#starttype` block, and
+* the `p'`-prefixed pointer that `#ccall` generates alongside the function —
+  the comment attaches to the function only.
+
+If your `Bindings.*` modules are an implementation detail that you re-export
+from a public module, add
+
+```haskell
+{-# OPTIONS_HADDOCK not-home #-}
+```
+
+to them, and make sure every type appearing in your public API is either
+re-exported from a module Haddock processes or exposed in `exposed-modules`.
+Types that only ever live in `other-modules` have no page to link to, which is
+what produces Haddock's *"could not find link destinations for ..."* warning.
+
+## Change log
+
 Unreleased
+
+* Emit the type signature before the value in #num, #fractional, #pointer and
+  #function_pointer, so that a Haddock comment written above the macro
+  attaches to the declaration Haddock documents.
 
 * bindings-gpgme: hide the trust item API when building against gpgme 2.0,
   which removed it (deprecated since 1.14), so the binding compiles against

--- a/bindings.dsl.h
+++ b/bindings.dsl.h
@@ -94,42 +94,47 @@
  */
 # define bc_patsig(name,constr) \
     printf("pattern ");bc_conid(name); \
-    printf(" :: (Eq a, %s a) => a",constr);
+    printf(" :: (Eq a, %s a) => a\n",constr);
 #else
 # define bc_patsig(name,constr)
 #endif
 
+/* Type signatures are emitted before the bindings they describe, so that a
+ * Haddock comment written above the macro invocation lands on the signature,
+ * which is what Haddock documents.
+ */
+
 #define hsc_num(name) \
-    bc_varid(# name);printf(" = ");bc_decimal(name);printf("\n"); \
     bc_varid(# name);printf(" :: (Num a) => a\n"); \
+    bc_varid(# name);printf(" = ");bc_decimal(name);printf("\n"); \
 
 #define hsc_fractional(name) \
-    bc_varid(# name);printf(" = ");bc_float(name);printf("\n"); \
     bc_varid(# name);printf(" :: (Fractional a) => a\n"); \
+    bc_varid(# name);printf(" = ");bc_float(name);printf("\n"); \
 
 #if __GLASGOW_HASKELL__ >= 710
 # define hsc_num_pattern(name) \
+     bc_patsig(# name,"Num"); \
      printf("pattern ");bc_conid(# name);printf(" <- ((== ("); \
      bc_decimal(name);printf(")) -> True) where\n    "); \
-     bc_conid(# name);printf(" = ");bc_decimal(name);printf("\n"); \
-     bc_patsig(# name,"Num");
+     bc_conid(# name);printf(" = ");bc_decimal(name);printf("\n");
 
 # define hsc_fractional_pattern(name) \
+     bc_patsig(# name,"Fractional"); \
      printf("pattern ");bc_conid(# name);printf(" <- ((== ("); \
      bc_float(name);printf(")) -> True) where\n    "); \
-     bc_conid(# name);printf(" = ");bc_float(name);printf("\n"); \
-     bc_patsig(# name,"Fractional");
+     bc_conid(# name);printf(" = ");bc_float(name);printf("\n");
 #endif
 
 #define hsc_pointer(name) \
+    bc_varid(# name);printf(" :: Ptr a\n"); \
     bc_varid(# name);printf(" = wordPtrToPtr "); \
     bc_wordptr(name);printf("\n"); \
-    bc_varid(# name);printf(" :: Ptr a\n"); \
 
 #define hsc_function_pointer(name) \
+    bc_varid(# name);printf(" :: FunPtr a\n"); \
     bc_varid(# name);printf(" = (castPtrToFunPtr . wordPtrToPtr) "); \
     bc_wordptr(name);printf("\n"); \
-    bc_varid(# name);printf(" :: FunPtr a\n"); \
 
 #ifdef BINDINGS_STDCALLCONV
 #define hsc_ccall(name,type) hsc_callconv(name,stdcall,type)


### PR DESCRIPTION
Fixes #11

Haddock documents a value through its type signature and ignores a doc comment
attached to a bare value binding. `#num`, `#fractional`, `#pointer` and
`#function_pointer` all printed the binding before the signature, so a `-- |`
written above one of these macros in a `.hsc` was silently dropped. Swapping the
two makes the comment attach; GHC does not care about the order, and the set of
generated declarations is unchanged. The pattern synonym signature moves ahead of
the synonym in `#num_pattern` / `#fractional_pattern` for the same reason.

The README gains a short Haddock section: which macros take a `-- |`, and the two
things that cannot be documented (record fields of a `#starttype`, and the `p'`
half of a `#ccall`).

The specific *"could not find link destinations"* warning in the issue is not
caused by the DSL — it comes from `Bindings.*` modules sitting in `other-modules`,
so the types they define have no Haddock page for the public API to link to. The
new README section covers that (`OPTIONS_HADDOCK not-home` plus re-exporting or
exposing the modules).