### PR TITLE
Add #array2d_field for two-dimensional array struct members

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Unreleased
 
+* Add #array2d_field, for struct members declared as two-dimensional arrays.
+  #array_field could not describe them: its element count was recovered by
+  dividing the member's byte size by the sizeOf of the Haskell type, which for
+  a decayed row (Ptr CChar) is the pointer size rather than the row size.
+
+* Element counts for #array_field and #union_array_field are now computed in C,
+  from the size of the member's first element, instead of at the Haskell level.
+
 * bindings-gpgme: hide the trust item API when building against gpgme 2.0,
   which removed it (deprecated since 1.14), so the binding compiles against
   both the 1.x and 2.x series.

--- a/bindings.dsl.h
+++ b/bindings.dsl.h
@@ -26,6 +26,7 @@
     "import Foreign.C.String (CString,CStringLen,CWString,CWStringLen)\n" \
     "import Foreign.Marshal.Alloc (alloca)\n" \
     "import Foreign.Marshal.Array (peekArray,pokeArray)\n" \
+    "import Foreign.Marshal.Utils (moveBytes)\n" \
     "import Data.Int\n" \
     "import Data.Word\n" \
     ); \
@@ -222,8 +223,8 @@
     printf(" -> (");bc_typemarkup(# type);printf(")\n"); \
 
 static struct {
-	int n, is_union[500], is_fam[500];
-	uintmax_t array_size[500], offset[500];
+	int n, is_union[500], is_fam[500], is_2d[500];
+	uintmax_t array_size[500], elem_size[500], offset[500];
 	char fname[500][1000], ftype[500][1000];
 } bc_fielddata;
 
@@ -248,8 +249,10 @@ static struct {
      bc_fielddata.offset[index] = (uintmax_t) \
          ((char*)&bc_refdata.v.name - (char*)&bc_refdata.v); \
      bc_fielddata.array_size[index] = 0; \
+     bc_fielddata.elem_size[index] = 0; \
      bc_fielddata.is_union[index] = u; \
      bc_fielddata.is_fam[index] = f; \
+     bc_fielddata.is_2d[index] = 0; \
      strcpy(bc_fielddata.fname[index],# name); \
      strcpy(bc_fielddata.ftype[index],type); \
 
@@ -264,11 +267,19 @@ static struct {
 
 #define hsc_array_field(name,type) \
      bc_basicfield(name,# type,0,0); \
-     bc_fielddata.array_size[index] = sizeof bc_refdata.v.name \
+     bc_fielddata.array_size[index] = sizeof bc_refdata.v.name; \
+     bc_fielddata.elem_size[index] = sizeof bc_refdata.v.name[0] \
 
 #define hsc_union_array_field(name,type) \
      bc_basicfield(name,# type,1,0); \
-     bc_fielddata.array_size[index] = sizeof bc_refdata.v.name \
+     bc_fielddata.array_size[index] = sizeof bc_refdata.v.name; \
+     bc_fielddata.elem_size[index] = sizeof bc_refdata.v.name[0] \
+
+#define hsc_array2d_field(name,type) \
+     bc_basicfield(name,# type,0,0); \
+     bc_fielddata.array_size[index] = sizeof bc_refdata.v.name; \
+     bc_fielddata.elem_size[index] = sizeof bc_refdata.v.name[0]; \
+     bc_fielddata.is_2d[index] = 1 \
 
 #define hsc_stoptype(dummy) \
      printf("data ");bc_conid(typename);printf(" = "); \
@@ -316,13 +327,9 @@ static struct {
          printf(" v vf = alloca $ \\p -> do\n"); \
          printf("  poke p v\n"); \
          if (bc_fielddata.array_size[i] > 0) \
-            { \
-             printf("  let s%d = div %" PRIuMAX " $ sizeOf $ (undefined :: ", \
-               i, bc_fielddata.array_size[i]); \
-             bc_typemarkup(bc_fielddata.ftype[i]); \
-             printf(")\n  pokeArray (plusPtr p %" PRIuMAX ") $ take s%d vf", \
-               bc_fielddata.offset[i], i); \
-            } \
+             printf("  pokeArray (plusPtr p %" PRIuMAX ") $ take %" PRIuMAX " vf", \
+               bc_fielddata.offset[i], \
+               bc_fielddata.array_size[i] / bc_fielddata.elem_size[i]); \
          else \
            printf("  pokeByteOff p %" PRIuMAX " vf", \
                bc_fielddata.offset[i]); \
@@ -347,14 +354,15 @@ static struct {
          printf("    v%d <- ",i); \
          if (bc_fielddata.is_fam[i]) \
             printf("return []"); \
+         else if (bc_fielddata.is_2d[i]) \
+            printf("return [plusPtr _p (%" PRIuMAX " + %" PRIuMAX " * k) " \
+                   "| k <- [0 .. %" PRIuMAX "]]", \
+              bc_fielddata.offset[i], bc_fielddata.elem_size[i], \
+              bc_fielddata.array_size[i] / bc_fielddata.elem_size[i] - 1); \
          else if (bc_fielddata.array_size[i] > 0) \
-           { \
-            printf ("let s%d = div %" PRIuMAX " $ sizeOf $ (undefined :: ", \
-              i, bc_fielddata.array_size[i]); \
-            bc_typemarkup(bc_fielddata.ftype[i]); \
-            printf(") in peekArray s%d (plusPtr _p %" PRIuMAX ")", \
-              i, bc_fielddata.offset[i]); \
-           } \
+            printf("peekArray %" PRIuMAX " (plusPtr _p %" PRIuMAX ")", \
+              bc_fielddata.array_size[i] / bc_fielddata.elem_size[i], \
+              bc_fielddata.offset[i]); \
          else \
             printf("peekByteOff _p %" PRIuMAX "", bc_fielddata.offset[i]); \
          printf("\n"); \
@@ -370,14 +378,18 @@ static struct {
          if (bc_fielddata.is_fam[i]) \
             printf("    pokeArray (plusPtr _p %" PRIuMAX ") v%d", \
               bc_fielddata.offset[i],i); \
+         else if (bc_fielddata.is_2d[i]) \
+            printf("    sequence_ [moveBytes (plusPtr _p (%" PRIuMAX \
+                   " + %" PRIuMAX " * k)) r %" PRIuMAX \
+                   " | (k,r) <- zip [0 .. %" PRIuMAX "] v%d]", \
+              bc_fielddata.offset[i], bc_fielddata.elem_size[i], \
+              bc_fielddata.elem_size[i], \
+              bc_fielddata.array_size[i] / bc_fielddata.elem_size[i] - 1, i); \
          else if (bc_fielddata.array_size[i] > 0) \
-           { \
-            printf("    let s%d = div %" PRIuMAX " $ sizeOf $ (undefined :: ", \
-              i, bc_fielddata.array_size[i]); \
-            bc_typemarkup(bc_fielddata.ftype[i]); \
-            printf(")\n    pokeArray (plusPtr _p %" PRIuMAX ") (take s%d v%d)", \
-              bc_fielddata.offset[i], i, i); \
-           } \
+            printf("    pokeArray (plusPtr _p %" PRIuMAX ") (take %" PRIuMAX \
+                   " v%d)", \
+              bc_fielddata.offset[i], \
+              bc_fielddata.array_size[i] / bc_fielddata.elem_size[i], i); \
          else \
             printf("    pokeByteOff _p %" PRIuMAX " v%d", \
               bc_fielddata.offset[i],i); \


### PR DESCRIPTION
Fixes #12

A struct member like `char x[8][255]` cannot be described with `#array_field`.
The reason is how the element count is recovered: `#array_field` only records
the member's *total* byte size in C, and the generated Haskell divides that by
the `sizeOf` of the *declared Haskell type* to get the number of elements. For a
two-dimensional array the inner row decays to `Ptr CChar`, so the divisor is the
pointer size (8) rather than the row size (255). The result is 255 elements
instead of 8: `peek` reads far past the member and `poke` scribbles 255 raw
pointers over the struct.

The element size is something C knows and Haskell has to guess at, so this
records it: `#array_field` and friends now also capture `sizeof member[0]`, and
the element count becomes a compile-time constant instead of a `div ... sizeOf`
expression in the generated code. For every existing one-dimensional binding
the element size and the `sizeOf` of the declared type are the same number, so
the generated code is unchanged in meaning.

On top of that, `#array2d_field` is added. It keeps the field's Haskell type as
a list of row pointers, but `peek` now hands back pointers *into* the struct
(offset + rowsize * k) rather than pretending the rows are values, and `poke`
copies whole rows back. Because `peek` returns interior pointers, a
peek/poke round-trip can pass identical source and destination pointers, which
is undefined behaviour for `memcpy`; `moveBytes` (`memmove`) is used deliberately
for that reason.

`#array_field` is untouched in meaning and no existing binding needs to change.
For auto-generated bindings to benefit, c2hsc (jwiegley/c2hsc) will need to
learn to emit `#array2d_field` where it currently emits `#array_field` for a
two-dimensional member.

Verified by hand-compiling the C program hsc2hs generates for a struct with
`char x[8][255]`, `int y[10]` and `char *z[4]`: the one-dimensional fields keep
their existing offsets and counts (10 and 4), and the two-dimensional field now
yields 8 rows at a 255-byte stride matching the real row addresses.