### PR TITLE
Document hsc2hs cross-compilation incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ drops the flag and lets the normal compile-and-run path proceed under emulation:
 ```sh
 #!/bin/sh
 # hsc2hs-no-cross, used via --with-hsc2hs=/path/to/hsc2hs-no-cross
-args=""
 for a in "$@"; do
+  shift
   case "$a" in
     -x|--cross-compile) ;;
-    *) args="$args $a" ;;
+    *) set -- "$@" "$a" ;;
   esac
 done
-exec hsc2hs $args
+exec hsc2hs "$@"
 ```
 
 Otherwise, write plain `.hsc` without bindings-DSL for the modules you need to

--- a/README.md
+++ b/README.md
@@ -29,6 +29,45 @@ extra-lib-dirs:
   - /opt/homebrew/opt/libgpg-error/lib
 ```
 
+## Cross compilation
+
+bindings-DSL does not work with `hsc2hs --cross-compile` (see
+[#38](https://github.com/rethab/bindings-dsl/issues/38)). Every construct
+(`#strict_import`, `#starttype`, `#ccall`, ...) is a custom hsc2hs construct that
+emits Haskell while the generated C program runs. Cross mode never runs that
+program: it recognises only a fixed set of built-in directives and rejects
+everything else with
+
+```
+directive strict_import cannot be handled in cross-compilation mode
+```
+
+`--via-asm` does not help, it only changes how cross mode extracts constants. No
+change to `bindings.dsl.h` can lift this; it needs hsc2hs to support custom
+constructs when cross compiling.
+
+Cross compiling still works if you can execute target binaries, e.g. with
+qemu-user plus `binfmt_misc`, or wine for Windows targets. Cabal gets in the way
+here: it passes `-x` to hsc2hs whenever the host platform differs from the build
+platform, and hsc2hs has no flag to undo that. Point Cabal at a wrapper that
+drops the flag and lets the normal compile-and-run path proceed under emulation:
+
+```sh
+#!/bin/sh
+# hsc2hs-no-cross, used via --with-hsc2hs=/path/to/hsc2hs-no-cross
+args=""
+for a in "$@"; do
+  case "$a" in
+    -x|--cross-compile) ;;
+    *) args="$args $a" ;;
+  esac
+done
+exec hsc2hs $args
+```
+
+Otherwise, write plain `.hsc` without bindings-DSL for the modules you need to
+cross compile.
+
 ## Changelog
 
 Unreleased


### PR DESCRIPTION
bindings-DSL is built entirely on custom hsc2hs constructs, which `hsc2hs --cross-compile` cannot handle: cross mode never runs the generated C program and only recognises its own built-in directives. That is not fixable in `bindings.dsl.h`, so the least we can do is say so, instead of leaving people to find out from a build error and a closed issue.

Also documents the way out for people who can emulate the target, which is non-obvious because Cabal forces `-x` on hsc2hs whenever host != build platform and hsc2hs has no flag to override it.

Closes #38