### PR TITLE
Build bindings-libcddb and bindings-hdf5 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Portable packages that build with only a Haskell toolchain: the
+  # Portable packages that need no system library of their own: the
   # bindings-DSL library itself and bindings-posix. Exercised across a
   # range of GHC versions.
   build:
@@ -25,6 +25,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      # cabal resolves every package in the project before it builds any of
+      # them, so bindings-libcddb's pkg-config dependency has to be
+      # satisfiable even in jobs that never build it.
+      - name: Install project-wide pkg-config dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcddb2-dev pkg-config
 
       - name: Set up GHC ${{ matrix.ghc }}
         uses: haskell-actions/setup@v2
@@ -97,10 +105,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # libcddb2-dev is not a gpgme dependency: it is there so that cabal can
+      # resolve bindings-libcddb's pkg-config dependency, which it does for
+      # the whole project regardless of the build target.
       - name: Install gpgme build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgpg-error-dev libassuan-dev
+          sudo apt-get install -y libgpg-error-dev libassuan-dev libcddb2-dev pkg-config
 
       - name: Cache gpgme ${{ matrix.gpgme.version }}
         id: cache-gpgme
@@ -146,3 +157,77 @@ jobs:
           cabal build bindings-gpgme \
             --extra-include-dirs="$GPGME_PREFIX/include" \
             --extra-lib-dirs="$GPGME_PREFIX/lib"
+
+  # GCC 14 turned -Wincompatible-pointer-types into an error, which breaks the
+  # inline wrappers this binding generates (issue #46). The runner image still
+  # defaults to GCC 13, which compiles them happily, so the compiler is pinned
+  # explicitly: with the default toolchain this job would stay green while
+  # everyone on a current distro is broken.
+  libcddb:
+    name: bindings-libcddb (GCC 14)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install libcddb and GCC 14
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcddb2-dev pkg-config gcc-14
+
+      - name: Set up GHC
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: '9.12'
+          cabal-version: 'latest'
+          cabal-update: true
+
+      - name: Cache cabal store
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ runner.os }}-libcddb-${{ hashFiles('**/*.cabal', 'cabal.project') }}
+          restore-keys: ${{ runner.os }}-libcddb-
+
+      - name: Build
+        run: cabal build bindings-libcddb --with-gcc=gcc-14
+
+  # Debian and Ubuntu keep the HDF5 headers and libraries in a serial/parallel
+  # split under their own directories, and the package's buildinfo only passes
+  # HDF5_CFLAGS along -- not the include and library paths that its configure
+  # script discovers. Until that is fixed in the package, CI has to hand the
+  # paths to cabal itself, otherwise the build cannot even find hdf5.h.
+  hdf5:
+    name: bindings-hdf5
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install HDF5
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libhdf5-dev libcddb2-dev pkg-config
+
+      - name: Set up GHC
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: '9.12'
+          cabal-version: 'latest'
+          cabal-update: true
+
+      - name: Cache cabal store
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ runner.os }}-hdf5-${{ hashFiles('**/*.cabal', 'cabal.project') }}
+          restore-keys: ${{ runner.os }}-hdf5-
+
+      - name: Build
+        run: |
+          arch=$(gcc -print-multiarch)
+          cabal build bindings-hdf5 \
+            --extra-include-dirs=/usr/include/hdf5/serial \
+            --extra-lib-dirs="/usr/lib/$arch/hdf5/serial"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # cabal resolves every package in the project before it builds any of
-      # them, so bindings-libcddb's pkg-config dependency has to be
-      # satisfiable even in jobs that never build it.
+      # cabal resolves the whole project, so bindings-libcddb's
+      # pkgconfig-depends must be satisfiable even here.
       - name: Install project-wide pkg-config dependencies
         run: |
           sudo apt-get update
@@ -105,9 +104,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # libcddb2-dev is not a gpgme dependency: it is there so that cabal can
-      # resolve bindings-libcddb's pkg-config dependency, which it does for
-      # the whole project regardless of the build target.
+      # libcddb2-dev is not a gpgme dependency; the solver needs it (see the
+      # build job).
       - name: Install gpgme build dependencies
         run: |
           sudo apt-get update
@@ -158,11 +156,8 @@ jobs:
             --extra-include-dirs="$GPGME_PREFIX/include" \
             --extra-lib-dirs="$GPGME_PREFIX/lib"
 
-  # GCC 14 turned -Wincompatible-pointer-types into an error, which breaks the
-  # inline wrappers this binding generates (issue #46). The runner image still
-  # defaults to GCC 13, which compiles them happily, so the compiler is pinned
-  # explicitly: with the default toolchain this job would stay green while
-  # everyone on a current distro is broken.
+  # GCC 14 is pinned because the runner default (GCC 13) does not error on
+  # incompatible pointer types and would have missed #46.
   libcddb:
     name: bindings-libcddb (GCC 14)
     runs-on: ubuntu-latest
@@ -193,11 +188,9 @@ jobs:
       - name: Build
         run: cabal build bindings-libcddb --with-gcc=gcc-14
 
-  # Debian and Ubuntu keep the HDF5 headers and libraries in a serial/parallel
-  # split under their own directories, and the package's buildinfo only passes
-  # HDF5_CFLAGS along -- not the include and library paths that its configure
-  # script discovers. Until that is fixed in the package, CI has to hand the
-  # paths to cabal itself, otherwise the build cannot even find hdf5.h.
+  # Debian/Ubuntu install HDF5 under a serial/parallel split that the
+  # package's buildinfo.in does not pass along, so the paths are given to
+  # cabal directly.
   hdf5:
     name: bindings-hdf5
     runs-on: ubuntu-latest

--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,5 @@ packages:
   .
   bindings-posix
   bindings-gpgme
+  bindings-libcddb
+  bindings-hdf5


### PR DESCRIPTION
cabal.project only listed `.`, bindings-posix and bindings-gpgme, so the
other bindings were never built by CI and regressed silently: #46 was
reported from the outside.

Add bindings-libcddb and bindings-hdf5 to the project, with a job each.

bindings-libcddb pins gcc-14. The runner default (GCC 13) does not turn
-Wincompatible-pointer-types into an error and would not have caught
#46 (since fixed by #54).

bindings-hdf5 needs --extra-include-dirs/--extra-lib-dirs: Debian and
Ubuntu install HDF5 under a serial/parallel split, and the package's
buildinfo.in only interpolates @HDF5_CFLAGS@, not the -I/-L paths its
own configure discovers. Fixing that touches a released package, so it
is out of scope here.

cabal resolves every project package before building any target, so the
solver needs libcddb installed even in jobs (and local clones) that
never build bindings-libcddb. Hence the extra apt installs.

Still not covered: bindings-directfb, -fann, -glib, -gsl, -libffi,
-sqlite3.
