### PR TITLE
Call out the array_field behavioral edge in the changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,18 @@ cross compile.
 
 Unreleased
 
-* Add #array2d_field, for struct members declared as two-dimensional arrays.
-  #array_field could not describe them: its element count was recovered by
-  dividing the member's byte size by the sizeOf of the Haskell type, which for
-  a decayed row (Ptr CChar) is the pointer size rather than the row size.
+* Add #array2d_field for members like char x[8][255], which #array_field
+  miscompiled: it divided the member size by sizeOf (Ptr CChar) and produced
+  255 rows instead of 8. Declare the type as the row pointer (Ptr CChar);
+  peek returns pointers into the struct, poke memmoves each row back.
 
-* Element counts for #array_field and #union_array_field are now computed in C,
-  from the size of the member's first element, instead of at the Haskell level.
+* #array_field and #union_array_field element counts are now baked in from C
+  (sizeof member / sizeof member[0]) instead of dividing by the declared
+  Haskell type's sizeOf at runtime. Beware: if your declared type's sizeOf
+  does not match the C element size, the count changes. The old code never
+  read past the member; the new code reads count * sizeOf bytes and will
+  overrun it if the declared type is too big. Correctly declared bindings
+  generate identical code.
 
 * bindings-gpgme: hide the trust item API when building against gpgme 2.0,
   which removed it (deprecated since 1.14), so the binding compiles against


### PR DESCRIPTION
Rewords the two #array2d_field entries added in #56.

The element count for #array_field now comes from C, so a binding whose declared Haskell type does not match the C element size gets a different count than before, and can read past the member — the old div-by-sizeOf code never did. Such a binding was already wrong, but it was memory-safe, and the entry as written does not warn anyone about it. Also states how to declare an #array2d_field member (row pointer, not element type), which is the first thing you get wrong when you reach for it.